### PR TITLE
Add tilde alias to webpack config

### DIFF
--- a/generators/app/templates/webpack.config.js
+++ b/generators/app/templates/webpack.config.js
@@ -30,6 +30,9 @@ const config = {
     stats: {
         colors: true
     },
+    resolve: {
+        alias: { '~': path.resolve(__dirname, 'node_modules') }
+    },
     plugins: [
         new webpack.DefinePlugin({
             'process.env': {


### PR DESCRIPTION
Useful for when you want to import specific files within the `node_modules` folder via SCSS.

### Example usage
```scss
@import '~video-react/dist/video-react.css'
```